### PR TITLE
feat: Assign RBAC administrator privileges by default

### DIFF
--- a/main.bicep
+++ b/main.bicep
@@ -24,6 +24,10 @@ param roleAssignments roleAssignmentType[] = [
   {
     roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c' // Contributor
   }
+  {
+    roleDefinitionId: 'f58310d9-a9f6-439a-9e8d-f62e7b41a168' // Role Based Access Control Administrator, with condition to prevent privilege escalation
+    condition: '''((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168}))'''
+  }
 ]
 
 var location = deployment().location


### PR DESCRIPTION
#20 

Tried to make the condition string easier to read by splitting it over multiple lines, instead of a long single line.
Unfortunately, this caused a bunch of new line escapes and litteral spaces for tabs to be included in the condition in the compiled ARM template. 