### PR TITLE
fix: parallel write operations to FIC resources not supported

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "16706739101650092258"
+      "version": "0.34.44.8038",
+      "templateHash": "3233861280613787245"
     }
   },
   "definitions": {
@@ -111,8 +111,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "4361191147276429572"
+              "version": "0.34.44.8038",
+              "templateHash": "7620549460909459402"
             }
           },
           "definitions": {
@@ -150,7 +150,9 @@
             "managedIdentity::federatedIdentityCredential": {
               "copy": {
                 "name": "managedIdentity::federatedIdentityCredential",
-                "count": "[length(parameters('federatedCredentials'))]"
+                "count": "[length(parameters('federatedCredentials'))]",
+                "mode": "serial",
+                "batchSize": 1
               },
               "type": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
               "apiVersion": "2023-07-31-preview",
@@ -234,8 +236,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "3185574087708451054"
+              "version": "0.34.44.8038",
+              "templateHash": "901676221518198243"
             }
           },
           "definitions": {

--- a/modules/managedIdentity.bicep
+++ b/modules/managedIdentity.bicep
@@ -13,6 +13,8 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   name: managedIdentityName
   location: resourceGroup().location
 
+  // Parallel write operations to federated identity credential resources is currently not supported.
+  @batchSize(1)
   resource federatedIdentityCredential 'federatedIdentityCredentials' = [
     for fic in federatedCredentials: {
       name: fic.name


### PR DESCRIPTION
Parallel write operations to `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials` resources is not currently supported.

Add a `batchSize` decorator to force write operations to be performed one resource at a time.